### PR TITLE
I18n setup

### DIFF
--- a/blocks/firefly-footer/firefly-footer.js
+++ b/blocks/firefly-footer/firefly-footer.js
@@ -2,15 +2,17 @@
 /* eslint-disable max-len */
 /* eslint-disable no-underscore-dangle */
 import { getLibs } from '../../scripts/utils.js';
-import { decorateI18n } from '../../scripts/scripts.js';
+import { decorateI18n, getLocaleFromCookie, convertLocaleFormat } from '../../scripts/scripts.js';
 
 const { createTag, getMetadata, decorateSVG } = await import(`${getLibs()}/utils/utils.js`);
 const BANNER_ENDPOINT = 'https://p13n.adobe.io/psdk/v2/content';
 
 async function decorateBanner(footerBanner) {
+  const locale = getLocaleFromCookie() || 'en-US';
+  const localeForAPI = convertLocaleFormat(locale);
   const surfaceId = 'Test_Firefly_Banner_Growth';
   const headers = new Headers({ 'X-Api-Key': 'clio-playground-web' });
-  const bannerResponse = await fetch(`${BANNER_ENDPOINT}?surfaceId=${surfaceId}&productLanguage=en_US&&clioPreferredLocale=en_US`, {
+  const bannerResponse = await fetch(`${BANNER_ENDPOINT}?surfaceId=${surfaceId}&productLanguage=${localeForAPI}&&clioPreferredLocale=${localeForAPI}`, {
     method: 'GET',
     headers,
   });

--- a/blocks/firefly-footer/firefly-footer.js
+++ b/blocks/firefly-footer/firefly-footer.js
@@ -2,6 +2,7 @@
 /* eslint-disable max-len */
 /* eslint-disable no-underscore-dangle */
 import { getLibs } from '../../scripts/utils.js';
+import decorateI18n from '../../scripts/scripts.js';
 
 const { createTag, getMetadata, decorateSVG } = await import(`${getLibs()}/utils/utils.js`);
 const BANNER_ENDPOINT = 'https://p13n.adobe.io/psdk/v2/content';
@@ -64,6 +65,7 @@ export default async function decorate(block) {
       });
 
       block.innerHTML = tempDiv.innerHTML;
+      decorateI18n(block);
     }
   }
 

--- a/blocks/firefly-footer/firefly-footer.js
+++ b/blocks/firefly-footer/firefly-footer.js
@@ -2,7 +2,7 @@
 /* eslint-disable max-len */
 /* eslint-disable no-underscore-dangle */
 import { getLibs } from '../../scripts/utils.js';
-import decorateI18n from '../../scripts/scripts.js';
+import { decorateI18n } from '../../scripts/scripts.js';
 
 const { createTag, getMetadata, decorateSVG } = await import(`${getLibs()}/utils/utils.js`);
 const BANNER_ENDPOINT = 'https://p13n.adobe.io/psdk/v2/content';

--- a/blocks/firefly-gallery/firefly-gallery.js
+++ b/blocks/firefly-gallery/firefly-gallery.js
@@ -1,6 +1,7 @@
 /* eslint-disable quote-props */
 /* eslint-disable no-underscore-dangle */
 import { getLibs } from '../../scripts/utils.js';
+import { getI18nValue, getLocaleFromCookie } from '../../scripts/scripts.js';
 
 const { loadIms } = await import(`${getLibs()}/utils/utils.js`);
 
@@ -64,7 +65,8 @@ async function getImages(link, accessToken = '', next = '') {
 
 async function addCards(cardContainer, images, accessToken = '') {
   let heightOfContainer = 0;
-  await images.forEach((image) => {
+  const locale = getLocaleFromCookie() || 'en-US';
+  await images.forEach(async (image) => {
     const rendition = image._links.rendition.href;
     const maxWidth = image._links.rendition.max_width;
     const maxHeight = image._links.rendition.max_height;
@@ -73,7 +75,7 @@ async function addCards(cardContainer, images, accessToken = '') {
     const authorName = image._embedded.owner.display_name;
     const authorImage = image._embedded.owner._links.images[0].href;
     const imageUrn = image.urn;
-    const prompt = image.title;
+    const prompt = image.custom.input['firefly#prompts'][locale];
     const imageUrl = rendition.replace('{format}', DEFAULT_FORMAT).replace('{dimension}', DEFAULT_DIMENSION).replace('{size}', DEFAULT_SIZE);
     const communityUrl = COMMUNITY_URL + imageUrn;
     const liked = Boolean(image.liked);
@@ -107,7 +109,7 @@ async function addCards(cardContainer, images, accessToken = '') {
         href: communityUrl,
         class: 'viewLink button',
       });
-      viewLink.textContent = 'View';
+      viewLink.textContent = await getI18nValue('community-thumbnail-view-button');
       const favorite = createTag('button', { class: `favorite ${liked ? 'hide' : ''}` });
       const favoriteSelected = createTag('button', { class: `favorite liked ${liked ? '' : 'hide'}` });
       const viewButton = createTag('button', { class: 'view' });

--- a/blocks/superhero/superhero.js
+++ b/blocks/superhero/superhero.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { getLibs, createOptimizedFireflyPicture } from '../../scripts/utils.js';
-import { getI18nValue } from '../../scripts/scripts.js';
+import { getI18nValue, getLocaleFromCookie } from '../../scripts/scripts.js';
 
 const { createTag } = await import(`${getLibs()}/utils/utils.js`);
 const ASSET_BASE_URL = 'https://community-hubs.adobe.io/api/v2/ff_community/assets/';
@@ -102,7 +102,7 @@ async function createPitcureFromAssetId(assetId, active, eager, fetchPriority) {
     const imageDetails = await resp.json();
     const imageHref = imageDetails._embedded.artwork._links.rendition.href;
     const imageUrl = imageHref.replace('{format}', DEFAULT_FORMAT).replace('{dimension}', DEFAULT_DIMENSION);
-    const userLocale = window.adobeIMS?.adobeIdData?.locale.replace('_', '-') || navigator.language || 'en-US';
+    const userLocale = getLocaleFromCookie() || window.adobeIMS?.adobeIdData?.locale.replace('_', '-') || navigator.language || 'en-US';
     const prompt = imageDetails.custom.input['firefly#prompts'][userLocale];
     const picture = createOptimizedFireflyPicture(imageUrl, prompt, active, eager, fetchPriority);
     const authorName = imageDetails._embedded.owner.display_name;

--- a/blocks/superhero/superhero.js
+++ b/blocks/superhero/superhero.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { getLibs, createOptimizedFireflyPicture } from '../../scripts/utils.js';
+import { getI18nValue } from '../../scripts/scripts.js';
 
 const { createTag } = await import(`${getLibs()}/utils/utils.js`);
 const ASSET_BASE_URL = 'https://community-hubs.adobe.io/api/v2/ff_community/assets/';
@@ -131,7 +132,7 @@ export default async function decorate(block) {
   const form = createTag('div', { class: 'generate-form' });
   const input = createTag('span', { contenteditable: 'true', class: 'generate-input' });
   const generateButton = createTag('button', { class: 'generate-button' });
-  generateButton.textContent = 'Generate';
+  generateButton.textContent = await getI18nValue('prompt-bar-generate-button-title');
   form.append(input, generateButton);
   contentContainer.append(form);
   const author = createTag('div', { class: 'author' });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -91,12 +91,12 @@ async function headerModal() {
   });
 }
 
-async function decorateI18n() {
+export default async function decorateI18n(block) {
   const locale = getMetadata('locale') || 'en-US'; // change this to pick locale from cookie set by header
   const resp = await fetch('/drafts/kunwar/language-store.json');
   if (resp.ok) {
     const json = await resp.json();
-    document.querySelectorAll('code').forEach((el) => {
+    block.querySelectorAll('code').forEach((el) => {
       const key = el.textContent.trim();
       if (key.startsWith('$')) {
         const jsonKey = key.slice(1);
@@ -116,7 +116,7 @@ async function loadPage() {
   const { loadArea, setConfig, loadMartech } = await import(`${miloLibs}/utils/utils.js`);
   // eslint-disable-next-line no-unused-vars
   const config = setConfig({ ...CONFIG, miloLibs });
-  await decorateI18n();
+  await decorateI18n(document.querySelector('main'));
   await loadArea();
   await headerModal();
   setTimeout(() => {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -92,7 +92,7 @@ async function headerModal() {
 }
 
 // Fetch locale from cookie
-function getLocaleFromCookie() {
+export function getLocaleFromCookie() {
   const match = document.cookie.match(/(^| )locale=([^;]+)/);
   if (match) {
     return match[2];

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -162,8 +162,9 @@ export async function decorateI18n(block) {
 }
 
 // Function to fetch value for a specific key
-export async function getI18nValue(key, locale = 'en-US', limit = 5000) {
+export async function getI18nValue(key, limit = 5000) {
   try {
+    const locale = getLocaleFromCookie() || 'en-US';
     const value = await langStoreCache.getValueByKey(key, locale, limit);
     return value ?? key;
   } catch (error) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -109,7 +109,7 @@ const langStoreCache = {
   cache: null,
 
   async fetchLangStoreData(locale, limit) {
-    const resp = await fetch(`/drafts/kunwar/lang-store.json?limit=${limit}&sheet=${locale}`);
+    const resp = await fetch(`/localization/lang-store.json?limit=${limit}&sheet=${locale}`);
     if (resp.ok) {
       const json = await resp.json();
       this.cache = json.data;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -93,7 +93,8 @@ async function headerModal() {
 
 export default async function decorateI18n(block) {
   const locale = getMetadata('locale') || 'en-US'; // change this to pick locale from cookie set by header
-  const resp = await fetch('/drafts/kunwar/language-store.json');
+  const limit = 5000;
+  const resp = await fetch(`/drafts/kunwar/lang-store.json?limit=${limit}&sheet=${locale}`);
   if (resp.ok) {
     const json = await resp.json();
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -100,6 +100,10 @@ export function getLocaleFromCookie() {
   return null;
 }
 
+export function convertLocaleFormat(locale) {
+  return locale.replace('-', '_');
+}
+
 // Process i18n text
 const langStoreCache = {
   cache: null,

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -159,6 +159,7 @@ export async function decorateI18n(block) {
     });
     el.parentNode.outerHTML = newTexts.join('');
   });
+}
 
 // Function to fetch value for a specific key
 export async function getI18nValue(key, locale = 'en-US', limit = 5000) {


### PR DESCRIPTION
I18n setup  #9 
- translates all default content
- added helper function to footer.js
- Footer Banner localized
- Super Hero to fetch i18n strings
- Gallery to fetch localized prompts

To TEST - please set a locale cookie to value say de-DE or any of the support languages in the lang-store.json

Test URLs
Before: https://i18n--firefly--adobecom.aem.page/drafts/kunwar/
After: https://i18n--firefly--adobecom.aem.page/drafts/kunwar/